### PR TITLE
setup.py: Fix readme file opening encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+import codecs
+
+from setuptools import find_packages, setup
 
 try:
     import pypandoc
     description = pypandoc.convert('README.md', 'rst')
 except:
-    description = open('README.md').read()
+    description = codecs.open('README.md', encoding='utf-8').read()
 
 setup(name="publicsuffixlist",
       version="0.5.0",
@@ -31,5 +33,3 @@ setup(name="publicsuffixlist",
           
         ],
       )
-
-


### PR DESCRIPTION
The file is unicode, but the open command did not specify the encoding. This only works when the system encoding is unicode too, which we can not rely on.