### PR TITLE
shebang, file mode fixes and script creation, codestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ with open("latest_psl.dat", "rb") as f:
 
 Works with both Python 2.x and 3.x.
 ```
-$ python -m publicsuffixlist.test
-$ python3 -m publicsuffixlist.test
+$ python2 setup.py test
+$ python3 setup.py test
 ```
 
 Drop-in compatibility code to replace [publicsuffix](https://pypi.python.org/pypi/publicsuffix/)

--- a/publicsuffixlist/__init__.py
+++ b/publicsuffixlist/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2014 ko-zu <causeless@gmail.com>
@@ -8,7 +7,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-import os,sys
+import os
+import sys
 
 __all__ = ["PublicSuffixList"]
 
@@ -21,9 +21,10 @@ PSLFILE = os.path.join(os.path.dirname(__file__), "public_suffix_list.dat")
 if sys.version_info >= (3, ):
     # python3.x
     def u(s):
-        return s if isinstance(s, str)     else s.decode(ENCODING)
+        return s if isinstance(s, str) else s.decode(ENCODING)
+
     def b(s):
-        return s if isinstance(s, bytes)   else s.encode(ENCODING)
+        return s if isinstance(s, bytes) else s.encode(ENCODING)
     basestr = str
     decodablestr = (str, bytes)
 
@@ -32,7 +33,7 @@ else:
     def u(s):
         return s if isinstance(s, unicode) else s.decode(ENCODING)
     def b(s):
-        return s if isinstance(s, str)     else s.encode(ENCODING)
+        return s if isinstance(s, str) else s.encode(ENCODING)
     basestr = basestring
     decodablestr = basestring
 
@@ -45,11 +46,9 @@ def decode_idn(domain):
     return b(domain).decode("idna")
 
 
-
-
 class PublicSuffixList(object):
     """ PublicSuffixList parser.
-    
+
     After __init__(), all instance methods become thread-safe.
     Most methods accept str or unicode as input in Python 2.x, str (not bytes) in Python 3.x.
     """
@@ -65,17 +64,15 @@ class PublicSuffixList(object):
 
         self.accept_unknown = accept_unknown
 
-        if source == None:
+        if source is None:
             try:
                 source = open(PSLFILE, "rb")
                 self._parse(source, accept_encoded_idn)
             finally:
                 if source:
                     source.close()
-        else:    
+        else:
             self._parse(source, accept_encoded_idn)
-
-
 
     def _parse(self, source, accept_encoded_idn):
         """ PSL parser core """
@@ -105,15 +102,13 @@ class PublicSuffixList(object):
         self._publicsuffix = frozenset(publicsuffix)
         self._maxlabel = maxlabel
 
-
     def suffix(self, domain, accept_unknown=None):
         """ Alias for privatesuffix """
         return self.privatesuffix(domain, accept_unknown)
 
-
     def privatesuffix(self, domain, accept_unknown=None):
         """ Return shortest suffix assigned for an individual.
-        
+
         domain: str or unicode to parse. (Required)
         accept_unknown: bool, assume unknown TLDs to be public suffix. (Default: object default)
 
@@ -121,7 +116,7 @@ class PublicSuffixList(object):
         Return None if domain has no private part.
         """
 
-        if accept_unknown == None:
+        if accept_unknown is None:
             accept_unknown = self.accept_unknown
 
         if not isinstance(domain, basestr):
@@ -133,7 +128,7 @@ class PublicSuffixList(object):
         if "\0" in domain or "" in labels:
             # not a valid domain
             return None
-        
+
         if ll <= 1:
             # is TLD
             return None
@@ -170,10 +165,9 @@ class PublicSuffixList(object):
             else:
                 return None
 
-
     def publicsuffix(self, domain, accept_unknown=None):
         """ Return longest publically shared suffix.
-        
+
         domain: str or unicode to parse. (Required)
         accept_unknown: bool, assume unknown TLDs to be public suffix. (Default: object default)
 
@@ -181,7 +175,7 @@ class PublicSuffixList(object):
         Return None if domain is not listed in PSL and accept_unknown is False.
         """
 
-        if accept_unknown == None:
+        if accept_unknown is None:
             accept_unknown = self.accept_unknown
 
         if not isinstance(domain, basestr):
@@ -207,14 +201,14 @@ class PublicSuffixList(object):
 
             if i > 0 and ("!*." + s) in self._publicsuffix:
                 return s
-    
+
             if ("!" + s) in self._publicsuffix:
                 # exact exclude
                 if i + 1 < ll:
                     return ".".join(labels[i+1:])
                 else:
                     return None
-            
+
             if i > 0 and ("*." + s) in self._publicsuffix:
                 return ".".join(labels[i-1:])
 
@@ -228,21 +222,18 @@ class PublicSuffixList(object):
             else:
                 return None
 
-
     def is_private(self, domain):
         """ Return True if domain is private suffix or sub-domain. """
-        return self.suffix(domain) != None
-
+        return self.suffix(domain) is not None
 
     def is_public(self, domain):
         """ Return True if domain is publix suffix. """
         return self.publicsuffix(domain) == domain
 
-
     def privateparts(self, domain):
         """ Return tuple of labels and the private suffix. """
         s = self.privatesuffix(domain)
-        if s == None:
+        if s is None:
             return None
         else:
             # I know the domain is valid and ends with private suffix
@@ -252,12 +243,10 @@ class PublicSuffixList(object):
             else:
                 return tuple(pre.split(".") + [s])
 
-
     def subdomain(self, domain, depth):
         """ Return so-called subdomain of specified depth in the private suffix. """
         p = self.privateparts(domain)
-        if p == None or depth > len(p) - 1:
+        if p is None or depth > len(p) - 1:
             return None
         else:
             return ".".join(p[-(depth+1):])
-

--- a/publicsuffixlist/compat.py
+++ b/publicsuffixlist/compat.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2014 ko-zu <causeless@gmail.com>
@@ -9,10 +8,10 @@
 #
 
 
-import os,sys,re
 from publicsuffixlist import PublicSuffixList as PSL
 
 __all__ = ["PublicSuffixList"]
+
 
 class PublicSuffixList(PSL):
     """ Drop in compatibility class to emulate publicsuffix module. """
@@ -30,4 +29,3 @@ class UnsafePublicSuffixList(PSL):
         """ Return shortest private suffix or longest public suffix. """
 
         return self.suffix(domain) or self.publicsuffix(domain) or ""
-

--- a/publicsuffixlist/test.py
+++ b/publicsuffixlist/test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2014 ko-zu <causeless@gmail.com>
@@ -8,10 +7,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-import os,sys,re
-from publicsuffixlist import PublicSuffixList, encode_idn, decode_idn, u, b
-
+import os
+import re
 import unittest
+
+from publicsuffixlist import PublicSuffixList, b, encode_idn, u
 
 
 class TestPSL(unittest.TestCase):
@@ -19,7 +19,6 @@ class TestPSL(unittest.TestCase):
     def setUp(self):
 
         self.psl = PublicSuffixList()
-        
 
     def test_typesafe(self):
         self.assertEqual(self.psl.suffix("www.example.co.jp").__class__, "example.co.jp".__class__)
@@ -28,11 +27,9 @@ class TestPSL(unittest.TestCase):
         self.assertEqual(self.psl.publicsuffix("www.example.co.jp").__class__, "co.jp".__class__)
         self.assertEqual(self.psl.publicsuffix(u("www.example.co.jp")).__class__, u("co.jp").__class__)
 
-
     def test_uppercase(self):
         self.assertEqual(self.psl.suffix("wWw.eXaMpLe.cO.Jp"), "example.co.jp")
         self.assertEqual(self.psl.publicsuffix("wWw.eXaMpLe.cO.Jp"), "co.jp")
-
 
     def test_invaliddomain(self):
         self.assertEqual(self.psl.suffix("www..invalid"), None)
@@ -45,24 +42,20 @@ class TestPSL(unittest.TestCase):
         self.assertEqual(self.psl.publicsuffix("example.com."), None)
         self.assertEqual(self.psl.publicsuffix(""), None)
 
-
     def test_idn(self):
         tld = u("香港")
         self.assertEqual(self.psl.suffix(u("www.example.") + tld), u("example.") + tld)
         self.assertEqual(self.psl.publicsuffix(u("www.example.") + tld), tld)
 
-    
     def test_punycoded(self):
         tld = encode_idn(u("香港"))
         self.assertEqual(self.psl.suffix(u("www.example.") + tld), u("example.") + tld)
         self.assertEqual(self.psl.publicsuffix(u("www.example.") + tld), tld)
 
-
     def test_suffix_deny_public(self):
         self.assertEqual(self.psl.suffix("com"), None)
         self.assertEqual(self.psl.suffix("co.jp"), None)
         self.assertEqual(self.psl.suffix("example.nagoya.jp"), None)
-
 
     def test_unknown(self):
         self.assertEqual(self.psl.suffix("www.example.unknowntld"), "example.unknowntld")
@@ -71,7 +64,6 @@ class TestPSL(unittest.TestCase):
         self.assertEqual(self.psl.publicsuffix("www.example.unknowntld"), "unknowntld")
         self.assertEqual(self.psl.publicsuffix("unknowntld"), "unknowntld")
 
-
     def test_deny_unknown(self):
         source = """
 known
@@ -79,7 +71,6 @@ known
         psl = PublicSuffixList(source.splitlines(), accept_unknown=False)
 
         self.assertEqual(psl.suffix("www.example.unknowntld"), None)
-
 
     def test_custom_psl(self):
         source = """
@@ -97,9 +88,6 @@ invalid
         self.assertEqual(psl.publicsuffix("example.invalid"), "example.invalid")
         self.assertEqual(psl.publicsuffix("test.invalid"), "invalid")
 
-
-
-
     def test_publicsuffix(self):
         self.assertEqual(self.psl.publicsuffix("www.example.com"), "com")
         self.assertEqual(self.psl.publicsuffix("unknowntld"), "unknowntld")
@@ -110,26 +98,22 @@ invalid
         self.assertEqual(self.psl.publicsuffix("example.nagoya.jp"), "example.nagoya.jp")
         self.assertEqual(self.psl.publicsuffix("test.example.nagoya.jp"), "example.nagoya.jp")
 
-
-
     def test_checkpublicsuffix_script(self):
         regex = re.compile(r"^checkPublicSuffix\(('[^']+'), (null|'[^']+')\);")
         with open(os.path.join(os.path.dirname(__file__), "test_psl.txt"), "rb") as f:
             ln = 0
-        
+
             for line in f:
                 ln += 1
                 l = line.decode("utf-8")
                 m = regex.match(l)
                 if not m:
                     continue
-    
+
                 arg = m.group(1).strip("'")
                 res = None if m.group(2) == "null" else m.group(2).strip("'")
-                
-                self.assertEqual(self.psl.suffix(arg), res, "in line {0}: {1}".format(ln, line.strip()))
-            
 
+                self.assertEqual(self.psl.suffix(arg), res, "in line {0}: {1}".format(ln, line.strip()))
 
     def test_typeerror(self):
 
@@ -138,13 +122,12 @@ invalid
         if b("") != "":
             # python3
             self.assertRaises(TypeError, lambda: self.psl.suffix(b("www.example.com")))
-        
 
     def test_compatclass(self):
 
         from publicsuffixlist.compat import PublicSuffixList
         psl = PublicSuffixList()
-        
+
         self.assertEqual(psl.get_public_suffix("test.example.com"), "example.com")
         self.assertEqual(psl.get_public_suffix("com"), "")
         self.assertEqual(psl.get_public_suffix(""), "")
@@ -153,18 +136,16 @@ invalid
 
         from publicsuffixlist.compat import UnsafePublicSuffixList
         psl = UnsafePublicSuffixList()
-        
+
         self.assertEqual(psl.get_public_suffix("test.example.com"), "example.com")
         self.assertEqual(psl.get_public_suffix("com"), "com")
         self.assertEqual(psl.get_public_suffix(""), "")
-
 
     def test_toomanylabels(self):
         d = "a." * 1000000 + "example.com"
 
         self.assertEqual(self.psl.publicsuffix(d), "com")
         self.assertEqual(self.psl.privatesuffix(d), "example.com")
-
 
     def test_flatstring(self):
         psl = PublicSuffixList(u("com\nnet\n"))
@@ -174,29 +155,25 @@ invalid
         psl = PublicSuffixList(b("com\nnet\n"))
         self.assertEqual(psl.publicsuffix("example.com"), "com")
 
-
     def test_privateparts(self):
         psl = self.psl
         self.assertEqual(psl.privateparts("aaa.www.example.com"), ("aaa", "www", "example.com"))
 
     def test_noprivateparts(self):
         psl = self.psl
-        self.assertEqual(psl.privateparts("com"), None) # no private part
+        self.assertEqual(psl.privateparts("com"), None)  # no private part
 
     def test_reconstructparts(self):
         psl = self.psl
         self.assertEqual(".".join(psl.privateparts("aaa.www.example.com")), "aaa.www.example.com")
-
 
     def test_subdomain(self):
         psl = self.psl
         self.assertEqual(psl.subdomain("aaa.www.example.com", depth=0), "example.com")
         self.assertEqual(psl.subdomain("aaa.www.example.com", depth=1), "www.example.com")
         self.assertEqual(psl.subdomain("aaa.www.example.com", depth=2), "aaa.www.example.com")
-        self.assertEqual(psl.subdomain("aaa.www.example.com", depth=3), None) # no sufficient depth
+        self.assertEqual(psl.subdomain("aaa.www.example.com", depth=3), None)  # no sufficient depth
 
 
 if __name__ == "__main__":
     unittest.main()
-
-

--- a/publicsuffixlist/update.py
+++ b/publicsuffixlist/update.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2014 ko-zu <causeless@gmail.com>
@@ -9,8 +8,15 @@
 #
 
 import os
+import time
+from email.utils import parsedate
 
-from publicsuffixlist import PSLURL, PSLFILE, PublicSuffixList
+from publicsuffixlist import PSLFILE, PSLURL, PublicSuffixList
+
+try:
+    import requests
+except ImportError:
+    requests = None
 
 
 def updatePSL(psl_file=PSLFILE):
@@ -18,13 +24,9 @@ def updatePSL(psl_file=PSLFILE):
 
     :param psl_file: path for the file to store the list. Default: PSLFILE
     """
-    try:
-        import requests
-    except ImportError:
+    if requests is None:
         raise Exception("Please install python-requests http(s) library. $ sudo pip install requests")
 
-    from email.utils import parsedate
-    import time
 
     r = requests.get(PSLURL)
     if r.status_code != requests.codes.ok or len(r.content) == 0:
@@ -35,9 +37,8 @@ def updatePSL(psl_file=PSLFILE):
     f.write(r.content)
     f.close()
 
-    f = open(psl_file + ".swp", "rb")
-    psl = PublicSuffixList(f)
-    f.close()
+    with open(psl_file + ".swp", "rb") as f:
+        psl = PublicSuffixList(f)
 
     os.rename(psl_file + ".swp", psl_file)
     if lastmod:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import codecs
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 try:
     import pypandoc
@@ -13,8 +13,8 @@ except:
 
 setup(name="publicsuffixlist",
       version="0.5.0",
-      packages=["publicsuffixlist",],
-      package_data = {
+      packages=["publicsuffixlist"],
+      package_data={
           "publicsuffixlist": [
               "public_suffix_list.dat",
               "test_psl.txt",
@@ -30,6 +30,6 @@ setup(name="publicsuffixlist",
           "Topic :: Internet :: Name Service (DNS)",
           "Topic :: Text Processing :: Filters",
           "Operating System :: OS Independent",
-          
+
         ],
       )

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,14 @@ setup(name="publicsuffixlist",
           "Operating System :: OS Independent",
 
         ],
+      extras_require={
+          "update": ["requests"],
+          "readme": ["pandoc"],
+        },
+      entry_points={
+          "console_scripts": [
+              "publicsuffixlist-download = publicsuffixlist.update:updatePSL",
+          ]},
+      test_suite="publicsuffixlist.test",
+      license='MPL-2.0',
       )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+import codecs
+
+from setuptools import find_packages, setup
 
 try:
     import pypandoc
     description = pypandoc.convert('README.md', 'rst')
 except:
-    description = open('README.md').read()
+    description = codecs.open('README.md', encoding='utf-8').read()
 
 setup(name="publicsuffixlist",
       version="0.5.0",
@@ -31,5 +33,3 @@ setup(name="publicsuffixlist",
           
         ],
       )
-
-


### PR DESCRIPTION
Remove shebangs in non-executable files
fix newlines and whitespaces
comparation with None only using `is`, not ==
removing unused imports, one import per line
only import at top of file

I did not care about "too long" lines

setup: add more useful options: 
add test suite (allows testing not-intalled code)
optional dependencies
and console scripts

Based on #4