### PR TITLE
Add Github Action to automate PSL updates

### DIFF
--- a/.github/workflows/update_psl.yaml
+++ b/.github/workflows/update_psl.yaml
@@ -1,0 +1,34 @@
+name: "Update PSL"
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create PR for PSL Update
+        id: psl_update_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          echo "Start."
+          # Configure git and Push updates
+          git config --global user.email github-actions@github.com
+          git config --global user.name github-actions
+          git config pull.rebase false
+          branch=psl-update-$GITHUB_RUN_ID
+          git checkout -b $branch
+          message='Automated PSL update'
+          # Add / update and commit
+          curl https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat > publicsuffixlist/public_suffix_list.dat
+          git add publicsuffixlist/public_suffix_list.dat
+          git commit -m 'Automated PSL update' || export NO_UPDATES=true
+          # Push
+          if [ "$NO_UPDATES" != "true" ] ; then
+              git push origin "$branch"
+              gh pr create --title "$message" --body "$message"
+          fi

--- a/.github/workflows/update_psl.yaml
+++ b/.github/workflows/update_psl.yaml
@@ -1,6 +1,8 @@
 name: "Update PSL"
 on:
   workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * 1'
 
 jobs:
   deploy:
@@ -29,6 +31,11 @@ jobs:
           git commit -m 'Automated PSL update' || export NO_UPDATES=true
           # Push
           if [ "$NO_UPDATES" != "true" ] ; then
+              VERSION=$(grep -E '^\s+version=' setup.py | sed -E 's/\s+version="(.*?)",/\1/')
+              NEXTVERSION=$(echo ${VERSION} | awk -F. -v OFS=. '{$NF += 1 ; print}')
+              sed -i "s/version=\"$VERSION\"/version=\"$NEXTVERSION\"/" setup.py
+              git add setup.py
+              git commit -m "Bump version from automated PSL update"
               git push origin "$branch"
               gh pr create --title "$message" --body "$message"
           fi


### PR DESCRIPTION
This PR partially implements #25 - submitting the new version to PyPI could also be automated.

Please note, the repo Settings need to allow Actions to create branches and PRs:

![image](https://user-images.githubusercontent.com/8847896/231312604-62b6b310-1390-4c13-99e8-97bf849052fc.png)
