### PR TITLE
Introduce GitHub Actions script for automated packaging

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,160 @@
+name: publish package
+
+on:
+  push:
+    branches:
+    - master
+  schedule:
+    - cron: "12 3 * * *"
+
+env:
+  BASEBRANCH: master
+  WORKBRANCH: autorelease
+  USERNAME: ko-zu (github-actions)
+  USEREMAIL: causeless@gmail.com
+
+concurrency: publish-package-with-updated-psl
+
+jobs:
+  verify-and-publish-main-branch:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ env.BASEBRANCH }}
+
+    - name: Set git config
+      run: |
+        git config user.name "$USERNAME"
+        git config user.email "$USEREMAIL"
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+        cache: "pip"
+        cache-dependency-path: "requirements-dev.txt"
+    
+    - name: Verify the psl
+      run: |
+        pip install --progress-bar off -r requirements-dev.txt 
+        pip install .
+        python -m publicsuffixlist.update
+
+        if ! git diff --exit-code publicsuffixlist/public_suffix_list.dat ; then
+          # PSL not updated
+          echo "PSL file is not up to date. Abort."
+          exit 1
+        fi
+
+        if ! python -m publicsuffixlist.test ; then
+          echo "Test failed. Abort."
+          exit 1
+        fi
+     
+    - name: Tag and release new version
+      run: |
+        BASEVERSION=$(sed -nr 's/^__version__ = "([0-9\.]+)"$/\1/p' setup.py)
+        [[ -z "$BASEVERSION" ]] && exit 1
+        echo "BASEVERSION=${BASEVERSION}" >> $GITHUB_ENV
+        TAG=v${BASEVERSION}
+        
+        git fetch origin $BASEBRANCH
+        git tag ${TAG} origin/$BASEBRANCH
+        git push origin ${TAG}
+        
+        # Create refreshed workbranch.
+        git checkout origin/$BASEBRANCH -b $WORKBRANCH
+
+        VERSION=$(sed -nr 's/^__version__ = "([0-9\.]+)"$/\1/p' setup.py)
+        NEWDATE=$(date -u "+%Y%m%d")
+        NEWVERSION=${VERSION}.${NEWDATE}
+        NEWTAG=v${NEWVERSION}-gha
+        
+        sed -ri 's/^__version__ = "[0-9\.]+\.[0-9]+"$/__version__ = "'${NEWVERSION}'"/' setup.py
+        
+        pip install .
+        python setup.py sdist --formats=gztar
+        python setup.py bdist_wheel --universal
+        
+        if ! python -m publicsuffixlist.test ; then
+          echo "Test failed. Abort."
+          exit 1
+        fi
+
+        git add setup.py publicsuffixlist/public_suffix_list.dat
+        git commit -m "Automated release: ${NEWTAG}"
+        git push -f origin $WORKBRANCH
+        git tag ${NEWTAG}
+        git push origin ${NEWTAG}
+
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+
+  scheduled-autorelease:
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ env.WORKBRANCH }}
+
+    - name: Set git config
+      run: |
+        git config user.name "$USERNAME"
+        git config user.email "$USEREMAIL"
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+        cache: "pip"
+        cache-dependency-path: "requirements-dev.txt"
+    
+    - name: Update automation branch
+      id: gennewversion
+      run: |
+        pip install --progress-bar off -r requirements-dev.txt 
+        pip install .
+        python -m publicsuffixlist.update
+
+        if git diff --exit-code publicsuffixlist/public_suffix_list.dat ; then
+          echo "No change in the PSL file. Skipping."
+          echo "release=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        VERSION=$(sed -nr 's/^__version__ = "([0-9\.]+)\.[0-9]+"$/\1/p' setup.py)
+        NEWDATE=$(date -u "+%Y%m%d")
+        NEWVERSION=${VERSION}.${NEWDATE}
+        NEWTAG=v${NEWVERSION}-gha
+        
+        sed -ri 's/^__version__ = "[0-9\.]+\.[0-9]+"$/__version__ = "'${NEWVERSION}'"/' setup.py
+        
+        pip install .
+        python setup.py sdist --formats=gztar
+        python setup.py bdist_wheel --universal
+        
+        if ! python -m publicsuffixlist.test ; then
+          echo "Test failed. Abort."
+          exit 1
+        fi
+
+        git add setup.py publicsuffixlist/public_suffix_list.dat
+        git commit -m "Automated release: ${NEWTAG}"
+        git push -f origin $WORKBRANCH
+        git tag ${NEWTAG}
+        git push origin ${NEWTAG}
+        
+        echo "release=true" >> $GITHUB_OUTPUT
+
+
+    - name: Publish package to TestPyPI
+      if: ${{ steps.gennewversion.outputs.release == 'true' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,16 @@
+Regarding Development Branches in this Repository
+=============
+
+- The `dev` branch may contain code that has not yet been released.
+- The `master` branch tracks the versions that have been released.
+- The `autorelease` branch is used for GitHub automation.
+
+To release new code:
+- Push the code to the dev branch and confirm that the commit passes the pytest.
+- Update the PSL file.
+- Change the version number in the setup.py file to X.Y.Z. (The date should not be included.)
+- Push the changes to the master branch.
+
+Once the new commit has been successfully verified by GitHub actions, it will be tagged as `vX.Y.Z`.
+GitHub actions will create a new package with a version number like `X.Y.Z.YYYYmmdd`.
+

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ License
 - PSL testcase dataset is public domain (CC0).
 
 
+Development / Packaging
+===
+This module and its packaging workflow are maintained in the author's repository located at https://github.com/ko-zu/psl.
+A new package, which includes the latest PSL file, is automatically generated and uploaded to PyPI.
+The last part of the version number represents the release date, for instance, `0.10.1.20230331`.
+
+
 Source / Link
 ===
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+requests
+twine
+wheel
+pip
+setuptools
+

--- a/requirements-update.txt
+++ b/requirements-update.txt
@@ -1,0 +1,1 @@
+requests

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,17 @@
 import codecs
 from setuptools import setup
 
+### version placeholder for release automation
+
+__version__ = "0.9.4"
+
+### Change the minor version before git push to the master branch.
+
+
 description = codecs.open('README.md', encoding='utf-8').read()
 
 setup(name="publicsuffixlist",
-      version="0.9.3",
+      version=__version__,
       packages=["publicsuffixlist"],
       package_data={
           "publicsuffixlist": [


### PR DESCRIPTION
This commit adds a GitHub Actions script that enables automated pre-release testing, tagging, and periodical updating of the PSL. When a new commit on the master branch is verified by GitHub Actions, it will be tagged as `vX.Y.Z`.
Additionally, it will be released as a new package with a version number like `X.Y.Z.YYYYmmdd` for each PSL update.
In this commit, autorelease script still uses TestPyPI for testing.